### PR TITLE
Fix published&target description in ports section

### DIFF
--- a/compose/compose-file/index.md
+++ b/compose/compose-file/index.md
@@ -954,16 +954,16 @@ port (a random host port will be chosen).
 The long form syntax allows the configuration of additional fields that can't be
 expressed in the short form.
 
-- `target`: the publicly exposed port
-- `published`: the port inside the container
+- `target`: the port inside the container
+- `published`: the publicly exposed port
 - `protocol`: the port protocol (`tcp` or `udp`)
 - `mode`: `host` for publishing a host port on each node, or `ingress` for a swarm
    mode port which will be load balanced.
 
 ```none
 ports:
-  - target: 8080
-    published: 80
+  - target: 80
+    published: 8080
     protocol: tcp
     mode: host
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->
In `ports` section of `LONG SYNTAX`, the `target` keywords actually means the port inside the container, and `published ` means the publicly exposed port in node. 

I test the compose below: 
```
version: "3.2"
services:
    nginx:
        image: nginx
        deploy:
          mode: replicated
          replicas: 3
        ports:
          - target: 80
            published: 8080
            protocol: tcp
            mode: host
```
using `docker ps ` it shows : 
```
6765ae09a25c        nginx:latest@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582   "nginx -g 'daemon ..."   14 minutes ago      Up 14 minutes       443/tcp, 10.246.2.4:8080->80/tcp   acs-node-3/bird1_nginx.1.akrxjfnm0gi23ii7fr90t2vm1
```

So, published is the published port in node and target is the container port inside the container.
### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
